### PR TITLE
CompositeMode ADT

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,6 @@
 ### 0.5.0.1
 API changes
+ * The `globalCompositeOperation` had its type changed from `Text -> Canvas ()` to `CompositeMode -> Canvas ()`, where `CompositeMode` is an ADT representing all of the possible canvas compositing modes.
  * The `(#)` function had its type generalized from `a -> (a -> Canvas b) -> Canvas b` to `a -> (a -> b) -> b`. This allows it to be used with font length units.
  * Added more type synonyms (`Interval`, `Degrees`, `Radians`, etc.) to more clearly indicate what functions expect constrained values.
  * `showbJS` (formerly `showJS`) and `jsStyle` now return a text `Builder` instead of a `String`. This change was introduced as part of a larger `blank-canvas` refactoring to increase performance. See the `Data.Text.Lazy.Builder` module from the `text` package for more details on how to use `Builder`s.

--- a/Graphics/Blank.hs
+++ b/Graphics/Blank.hs
@@ -46,6 +46,17 @@ module Graphics.Blank
           -- ** Compositing
         , globalAlpha
         , globalCompositeOperation
+        , CompositeMode(..)
+        , sourceOver
+        , sourceAtop
+        , sourceIn
+        , sourceOut
+        , destinationOver
+        , destinationAtop
+        , destinationIn
+        , destinationOut
+        , lighter
+        , xor
           -- ** Line styles
         , lineWidth
         , lineCap
@@ -124,6 +135,7 @@ module Graphics.Blank
         , Interval
         , Percentage
         , Radians
+        , CopyProperty(..)
         , RoundProperty(..)
         -- * @blank-canvas@ Extensions
         -- ** Reading from 'Canvas'

--- a/Graphics/Blank/Canvas.hs
+++ b/Graphics/Blank/Canvas.hs
@@ -77,7 +77,7 @@ data Method
         | FillText (Text, Double, Double)
         | forall canvasFont . CanvasFont canvasFont => Font canvasFont
         | GlobalAlpha Alpha
-        | GlobalCompositeOperation Text
+        | GlobalCompositeOperation CompositeMode
         | LineCap LineEndCap
         | LineJoin LineJoinCorner
         | LineTo (Double, Double)

--- a/Graphics/Blank/Cursor.hs
+++ b/Graphics/Blank/Cursor.hs
@@ -33,7 +33,6 @@ module Graphics.Blank.Cursor (
     , text
     , verticalText
     , alias
-    , copy
     , move
     , noDrop
     , notAllowed
@@ -57,7 +56,9 @@ module Graphics.Blank.Cursor (
     , grab
     , grabbing
     , url
+    , CopyProperty(..)
     ) where
 
 import Graphics.Blank.Canvas (cursor)
+import Graphics.Blank.JavaScript
 import Graphics.Blank.Types.Cursor

--- a/Graphics/Blank/Generated.hs
+++ b/Graphics/Blank/Generated.hs
@@ -46,7 +46,7 @@ instance T.Show Method where
   showb (FillText (a1,a2,a3)) = "fillText(" <> jsText a1 <> singleton ',' <> jsDouble a2 <> singleton ',' <> jsDouble a3 <> singleton ')'
   showb (Font (a1)) = "font = (" <> jsCanvasFont a1 <> singleton ')'
   showb (GlobalAlpha (a1)) = "globalAlpha = (" <> jsDouble a1 <> singleton ')'
-  showb (GlobalCompositeOperation (a1)) = "globalCompositeOperation = (" <> jsText a1 <> singleton ')'
+  showb (GlobalCompositeOperation (a1)) = "globalCompositeOperation = (" <> jsCompositeMode a1 <> singleton ')'
   showb (LineCap (a1)) = "lineCap = (" <> jsLineEndCap a1 <> singleton ')'
   showb (LineJoin (a1)) = "lineJoin = (" <> jsLineJoinCorner a1 <> singleton ')'
   showb (LineTo (a1,a2)) = "lineTo(" <> jsDouble a1 <> singleton ',' <> jsDouble a2 <> singleton ')'
@@ -171,7 +171,7 @@ font = Method . Font
 globalAlpha :: Alpha -> Canvas ()
 globalAlpha = Method . GlobalAlpha
 
-globalCompositeOperation :: Text -> Canvas ()
+globalCompositeOperation :: CompositeMode -> Canvas ()
 globalCompositeOperation = Method . GlobalCompositeOperation
 
 lineCap :: LineEndCap -> Canvas ()

--- a/Graphics/Blank/Types/Cursor.hs
+++ b/Graphics/Blank/Types/Cursor.hs
@@ -49,7 +49,7 @@ data Cursor = Auto         -- ^ The browser determines the cursor to display bas
             | Text         -- ^ <<https://developer.mozilla.org/files/3809/text.gif>>
             | VerticalText -- ^ <<https://developer.mozilla.org/@api/deki/files/3456/=vertical-text.gif>>
             | Alias        -- ^ <<https://developer.mozilla.org/@api/deki/files/3432/=alias.gif>>
-            | Copy         -- ^ <<https://developer.mozilla.org/@api/deki/files/3436/=copy.gif>>
+            | CopyCursor   -- ^ <<https://developer.mozilla.org/@api/deki/files/3436/=copy.gif>>
             | Move         -- ^ <<https://developer.mozilla.org/@api/deki/files/3443/=move.gif>>
             | NoDrop       -- ^ <<https://developer.mozilla.org/@api/deki/files/3445/=no-drop.gif>>
             | NotAllowed   -- ^ <<https://developer.mozilla.org/@api/deki/files/3446/=not-allowed.gif>>
@@ -75,6 +75,9 @@ data Cursor = Auto         -- ^ The browser determines the cursor to display bas
             | URL TS.Text Cursor
               -- ^ An image from a URL. Must be followed by another 'Cursor'.
     deriving (Eq, Ord)
+
+instance CopyProperty Cursor where
+    copy = CopyCursor
 
 instance IsString Cursor where
     fromString = read
@@ -102,7 +105,7 @@ instance Read Cursor where
           , Text         <$ stringCI "text"
           , VerticalText <$ stringCI "vertical-text"
           , Alias        <$ stringCI "alias"
-          , Copy         <$ stringCI "copy"
+          , CopyCursor   <$ stringCI "copy"
           , Move         <$ stringCI "move"
           , NoDrop       <$ stringCI "no-drop"
           , NotAllowed   <$ stringCI "not-allowed"
@@ -162,7 +165,7 @@ instance T.Show Cursor where
     showb Text         = "text"
     showb VerticalText = "vertical-text"
     showb Alias        = "alias"
-    showb Copy         = "copy"
+    showb CopyCursor   = "copy"
     showb Move         = "move"
     showb NoDrop       = "no-drop"
     showb NotAllowed   = "not-allowed"
@@ -240,10 +243,6 @@ verticalText = VerticalText
 -- | Shorthand for 'Alias'.
 alias :: Cursor
 alias = Alias
-
--- | Shorthand for 'Copy'.
-copy :: Cursor
-copy = Copy
 
 -- | Shorthand for 'Move'.
 move :: Cursor


### PR DESCRIPTION
I noticed that the argument to `globalCompositeOperation` can only be one of 11 possible choices (at least, on most browsers. Firefox has [more](https://developer.mozilla.org/en-US/docs/Web/CSS/blend-mode), but they're not widely supported), so I changed its argument from `Text` to a `CompositeMode` ADT to enforce greater type safety.

I'll make this a pull request for now, since we should probably avoid making significant API changes while the `blank-canvas` paper is being written.
