### PR TITLE
Incorporate natural-transformations

### DIFF
--- a/Graphics/Blank.hs
+++ b/Graphics/Blank.hs
@@ -558,7 +558,7 @@ The equivalent operator in @blank-canvas@ is (@#@). For example, it can be used
 to represent 'send'ing 'Canvas' commands to a 'DeviceContext':
 
 @
-blankCanvas 3000 $ \cxt ->
+blankCanvas 3000 $ \\cxt ->
     cxt # do
         moveTo(50,50)
         lineTo(200,100)

--- a/Graphics/Blank/Canvas.hs
+++ b/Graphics/Blank/Canvas.hs
@@ -162,15 +162,6 @@ showbGradientCommand grad = go grad . runGradientCommand
     go _ (Pure _) = mempty
     go g (Free c) = jsCanvasGradient g <> showb c <> singleton ';' <> foldMap (go grad) c
 
--- instance S.Show (GradientCommand a) where
---   showsPrec p = showsPrec p . FromTextShow
--- 
--- instance T.Show (GradientCommand a) where
---   showb = go . runGradientCommand
---     where
---       go (Pure _) = mempty
---       go (Free x) = showb x <> foldMap go x
-
 instance Transformation GradientCommand Canvas CanvasGradient where
   grad # comm = Command (GC grad comm)
 

--- a/Graphics/Blank/Canvas.hs
+++ b/Graphics/Blank/Canvas.hs
@@ -1,14 +1,23 @@
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE DeriveFoldable #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Graphics.Blank.Canvas where
 
 import           Control.Applicative
-import           Control.Monad (ap, liftM2)
+import           Control.Monad (ap, liftM, liftM2)
+import           Control.Monad.Free
+import           Control.Transformation
 
 import           Data.Aeson (FromJSON(..),Value(..),encode)
 import           Data.Aeson.Types (Parser, (.:))
@@ -23,7 +32,7 @@ import           Graphics.Blank.Types
 import           Graphics.Blank.Types.Cursor
 import           Graphics.Blank.Types.Font
 
-import           Prelude hiding (Show)
+import           Prelude.Compat hiding (Show)
 
 import qualified Text.Show as S (Show)
 import qualified Text.Show.Text as T (Show)
@@ -40,8 +49,8 @@ $(deriveShow ''TextMetrics)
 -----------------------------------------------------------------------------
 
 data Canvas :: * -> * where
-        Method    :: Method                      -> Canvas ()     -- <context>.<method>
-        Command   :: Command                     -> Canvas ()     -- <command>
+        Method    :: Method                      -> Canvas () -- <context>.<method>
+        Command   :: Command a                   -> Canvas a  -- <command>
         Function  :: T.Show a => Function a      -> Canvas a
         Query     :: T.Show a => Query a         -> Canvas a
         With      :: CanvasContext -> Canvas a   -> Canvas a
@@ -50,15 +59,15 @@ data Canvas :: * -> * where
         Return    :: a                           -> Canvas a
 
 instance Monad Canvas where
-        return = Return
-        (>>=) = Bind
+  return = Return
+  (>>=)  = Bind
 
 instance Applicative Canvas where
   pure  = return
   (<*>) = ap
 
 instance Functor Canvas where
-  fmap f c = c >>= return . f
+  fmap = liftM
 
 instance Monoid a => Monoid (Canvas a) where
   mappend = liftM2 mappend
@@ -109,22 +118,61 @@ data Method
         | Transform (Double, Double, Double, Double, Double, Double)
         | Translate (Double, Double)
 
-data Command
-  = Trigger Event
-  | forall color . CanvasColor color => AddColorStop (Interval, color) CanvasGradient
-  | forall msg . JSArg msg => Log msg
-  | Eval Text
+data Command :: * -> * where
+    Trigger :: Event                                 -> Command ()
+    GC      :: CanvasGradient -> (GradientCommand a) -> Command a
+    Log     :: forall msg . JSArg msg => msg         -> Command ()
+    Eval    :: Text                                  -> Command ()
 
-instance S.Show Command where
+instance S.Show (Command a) where
   showsPrec p = showsPrec p . FromTextShow
 
-instance T.Show Command where
+instance T.Show (Command a) where
   showb (Trigger e) = "Trigger(" <> (fromLazyText . decodeUtf8 $ encode e) <> singleton ')'
-  showb (AddColorStop (off,rep) g) = jsCanvasGradient g <> ".addColorStop("
-         <> jsDouble off <> singleton ',' <> jsCanvasColor rep
-         <> singleton ')'
+  showb (GC g c) = showbGradientCommand g c
   showb (Log msg) = "console.log(" <> showbJS msg <> singleton ')'
   showb (Eval cmd) = fromText cmd -- no escaping or interpretation
+
+-- The type paramter is only used for accumulating free-monadic values.
+data GradientCommand' a =
+    forall color. CanvasColor color => AddColorStop (Interval, color) a
+
+deriving instance Functor GradientCommand'
+deriving instance Foldable GradientCommand'
+
+instance S.Show (GradientCommand' a) where
+  showsPrec p = showsPrec p . FromTextShow
+
+instance T.Show (GradientCommand' a) where
+  showb (AddColorStop (off, rep) _) = ".addColorStop("
+       <> jsDouble off <> singleton ',' <> jsCanvasColor rep
+       <> singleton ')'
+
+-- | A command which must be invoked from a 'CanvasGradient' by use of the
+-- transformation operator (#). See 'addColorStop' for an example of how
+-- to do this.
+newtype GradientCommand a =
+    GradientCommand { runGradientCommand :: Free GradientCommand' a }
+  deriving (Functor, Applicative, Monad)
+
+showbGradientCommand :: CanvasGradient -> GradientCommand a -> Builder
+showbGradientCommand grad = go grad . runGradientCommand
+  where
+    go :: CanvasGradient -> Free GradientCommand' a -> Builder
+    go _ (Pure _) = mempty
+    go g (Free c) = jsCanvasGradient g <> showb c <> singleton ';' <> foldMap (go grad) c
+
+-- instance S.Show (GradientCommand a) where
+--   showsPrec p = showsPrec p . FromTextShow
+-- 
+-- instance T.Show (GradientCommand a) where
+--   showb = go . runGradientCommand
+--     where
+--       go (Pure _) = mempty
+--       go (Free x) = showb x <> foldMap go x
+
+instance Transformation GradientCommand Canvas CanvasGradient where
+  grad # comm = Command (GC grad comm)
 
 -----------------------------------------------------------------------------
 
@@ -151,10 +199,11 @@ trigger = Command . Trigger
 --
 -- @
 -- grd <- 'createLinearGradient'(0, 0, 10, 10)
--- grd # 'addColorStop'(0, 'red')
+-- grd # do 'addColorStop'(0, 'red')
+--          'addColorStop'(1, 'blue')
 -- @
-addColorStop :: CanvasColor color => (Interval, color) -> CanvasGradient -> Canvas ()
-addColorStop (off,rep) = Command . AddColorStop (off,rep)
+addColorStop :: CanvasColor color => (Interval, color) -> GradientCommand ()
+addColorStop stop = GradientCommand . Free . fmap pure $ AddColorStop stop ()
 
 -- | 'console_log' aids debugging by sending the argument to the browser @console.log@.
 console_log :: JSArg msg => msg -> Canvas ()

--- a/Graphics/Blank/Font.hs
+++ b/Graphics/Blank/Font.hs
@@ -79,7 +79,11 @@ module Graphics.Blank.Font
     , pc
     -- * Percentages
     , PercentageProperty(..)
+    -- * Suffix application
+    , (&)
     ) where
+
+import Data.Function.Compat ((&))
 
 import Graphics.Blank.Generated (font)
 import Graphics.Blank.Types.CSS

--- a/Graphics/Blank/Generated.hs
+++ b/Graphics/Blank/Generated.hs
@@ -255,8 +255,8 @@ fillText = Method . FillText
 -- ==== __Examples__
 -- 
 -- @
--- 'font' ('defFont' "Gill Sans Extrabold") { 'fontSize' = 40 # 'pt' }
--- 'font' ('defFont' 'sansSerif') { 'fontSize' = 80 # 'percent' }
+-- 'font' ('defFont' "Gill Sans Extrabold") { 'fontSize' = 40 & 'pt' }
+-- 'font' ('defFont' 'sansSerif') { 'fontSize' = 80 & 'percent' }
 -- 'font' ('defFont' 'serif') {
 --     'fontWeight' = 'bold'
 --   , 'fontStyle'  = 'italic'

--- a/Graphics/Blank/Types/Font.hs
+++ b/Graphics/Blank/Types/Font.hs
@@ -73,8 +73,8 @@ data Font = FontProperties
 -- @
 -- ('defFont' ["Gill Sans Extrabold", 'sansSerif']) {
 --     'fontStyle'  = 'italic'
---   , 'fontSize'   = 12 # 'px'
---   , 'lineHeight' = 14 # 'px'
+--   , 'fontSize'   = 12 & 'px'
+--   , 'lineHeight' = 14 & 'px'
 -- }
 -- @
 defFont :: [FontFamily] -> Font
@@ -398,8 +398,8 @@ instance T.Show FontWeight where
 --
 -- @
 -- ('defFont' ['sansSerif']) { 'fontSize' = 'xxSmall' }
--- ('defFont' ['sansSerif']) { 'fontSize' = 30 # 'pt' }
--- ('defFont' ['sansSerif']) { 'fontSize' = 50 # 'percent' }
+-- ('defFont' ['sansSerif']) { 'fontSize' = 30 & 'pt' }
+-- ('defFont' ['sansSerif']) { 'fontSize' = 50 & 'percent' }
 -- @
 data FontSize = XXSmallSize
               | XSmallSize
@@ -505,8 +505,8 @@ instance T.Show FontSize where
 -- @
 -- ('defFont' ['sansSerif']) { 'lineHeight' = 'normal' }
 -- ('defFont' ['sansSerif']) { 'lineHeight' = 50 }
--- ('defFont' ['sansSerif']) { 'lineHeight' = 30 # 'em' }
--- ('defFont' ['sansSerif']) { 'lineHeight' = 70 # 'percent' }
+-- ('defFont' ['sansSerif']) { 'lineHeight' = 30 & 'em' }
+-- ('defFont' ['sansSerif']) { 'lineHeight' = 70 & 'percent' }
 -- @
 data LineHeight = NormalLineHeight -- ^ Default.
                 | LineHeightNumber Double

--- a/Graphics/Blank/Utils.hs
+++ b/Graphics/Blank/Utils.hs
@@ -27,17 +27,6 @@ saveRestore m = do
     restore ()
     return r
 
-infixr 0 #
-
--- | The @#@-operator is the Haskell analog to the @.@-operator
---   in JavaScript. Example:
--- 
--- > grd # addColorStop(0, "#8ED6FF");
--- 
---   This can be seen as equivalent of @grd.addColorStop(0, "#8ED6FF")@.
-(#) :: a -> (a -> b) -> b
-(#) obj act = act obj
-
 -- | Read a file, and generate a data URL.
 --
 -- >  url <- readDataURL "image/png" "image/foo.png"

--- a/blank-canvas.cabal
+++ b/blank-canvas.cabal
@@ -67,26 +67,28 @@ Library
                        Paths_blank_canvas
 
   default-language:    Haskell2010
-  build-depends:       aeson              >= 0.7     && < 0.9,
-                       base64-bytestring  == 1.0.*,
-                       base               >= 4.6     && < 4.9,
-                       base-compat        >= 0.8.1   && < 1,
-                       bytestring         == 0.10.*,
-                       colour             >= 2.2     && < 3.0,
-                       containers         == 0.5.*,
-                       data-default-class == 0.0.*,
-                       http-types         == 0.8.*,
-                       mime-types         >= 0.1.0.3 && < 0.2,
-                       kansas-comet       >= 0.3.2   && < 0.4,
-                       scotty             >= 0.8     && < 0.10,
-                       stm                >= 2.2     && < 2.5,
-                       text               >= 1.1     && < 1.3,
-                       text-show          >= 0.6     && < 0.9,
-                       transformers       >= 0.3     && < 0.5,
-                       wai                == 3.*,
-                       wai-extra          >= 3.0.1   && < 3.1,
-                       warp               == 3.*,
-                       vector             >= 0.10    && < 0.11
+  build-depends:       aeson                  >= 0.7     && < 0.9,
+                       base64-bytestring      == 1.0.*,
+                       base                   >= 4.6     && < 4.9,
+                       base-compat            >= 0.8.1   && < 1,
+                       bytestring             == 0.10.*,
+                       colour                 >= 2.2     && < 3.0,
+                       containers             == 0.5.*,
+                       data-default-class     == 0.0.*,
+                       free                   >= 4.9     && < 5,
+                       http-types             == 0.8.*,
+                       mime-types             >= 0.1.0.3 && < 0.2,
+                       kansas-comet           >= 0.3.2   && < 0.4,
+                       natural-transformation >= 0.2,
+                       scotty                 >= 0.8     && < 0.10,
+                       stm                    >= 2.2     && < 2.5,
+                       text                   >= 1.1     && < 1.3,
+                       text-show              >= 0.6     && < 0.9,
+                       transformers           >= 0.3     && < 0.5,
+                       wai                    == 3.*,
+                       wai-extra              >= 3.0.1   && < 3.1,
+                       warp                   == 3.*,
+                       vector                 >= 0.10    && < 0.11
 
   GHC-options:         -Wall
   GHC-prof-options:    -Wall -auto-all -fsimpl-tick-factor=100000

--- a/examples/html5canvastutorial/Main.hs
+++ b/examples/html5canvastutorial/Main.hs
@@ -320,10 +320,11 @@ example_1_6_2 canvas = do
         let (w,h) = size canvas
         rect(0, 0, w, h)
         grd <- createLinearGradient(0, 0, w, h)
-        -- light blue
-        grd # addColorStop(0, "#8ED6FF")
-        -- dark blue
-        grd # addColorStop(1, "#004CB3")
+        grd # do 
+            -- light blue
+            addColorStop(0, "#8ED6FF")
+            -- dark blue
+            addColorStop(1, "#004CB3")
         Style.fillStyle grd;
         fill();
 
@@ -331,10 +332,11 @@ example_1_6_3 canvas = do
         let (w,h) = size canvas
         rect(0, 0, w, h)
         grd <- createRadialGradient (238, 50, 10, 238, 50, 300)
-        -- light blue
-        grd # addColorStop(0, "#8ED6FF")
-        -- dark blue
-        grd # addColorStop(1, "#004CB3")
+        grd # do 
+            -- light blue
+            addColorStop(0, "#8ED6FF")
+            -- dark blue
+            addColorStop(1, "#004CB3")
         Style.fillStyle grd;
         fill();
 

--- a/wiki-suite/Linear_Gradient.hs
+++ b/wiki-suite/Linear_Gradient.hs
@@ -10,10 +10,11 @@ main = blankCanvas 3000 $ \ context -> do
     send context $ do        
         rect(0, 0, width context, height context)
         grd <- createLinearGradient(0, 0, width context, height context)
-        -- light blue
-        grd # addColorStop(0, "#8ED6FF")
-        -- dark blue
-        grd # addColorStop(1, "#004CB3")
+        grd # do 
+            -- light blue
+            addColorStop(0, "#8ED6FF")
+            -- dark blue
+            addColorStop(1, "#004CB3")
         Style.fillStyle grd;
         fill();
 

--- a/wiki-suite/Radial_Gradient.hs
+++ b/wiki-suite/Radial_Gradient.hs
@@ -10,10 +10,11 @@ main = blankCanvas 3000 $ \ context -> do
     send context $ do
         rect(0, 0, width context, height context)
         grd <- createRadialGradient (238, 50, 10, 238, 50, 300)
-        -- light blue
-        grd # addColorStop(0, "#8ED6FF")
-        -- dark blue
-        grd # addColorStop(1, "#004CB3")
+        grd # do 
+            -- light blue
+            addColorStop(0, "#8ED6FF")
+            -- dark blue
+            addColorStop(1, "#004CB3")
         Style.fillStyle grd;
         fill();
 


### PR DESCRIPTION
My attempt at resolving issue #66. There are two major additions here:
1. A `Transformation Canvas IO DeviceContext` instance and a `Transformation GradientCommand Canvas CanvasGradient` instance
2. The `GradientCommand` data type. I used the [`Free`](http://hackage.haskell.org/package/free-4.12.1/docs/Control-Monad-Free.html) data type from `free` to make `GradientCommand` a monad.

It should be noted that `GradientCommand` is not as deeply embedded of a DSL as `Canvas` is. However, the only function that actually returns something of type `GradientCommand` is `addColorStop` (which returns `GradientCommand ()`), so I figured a deep DSL wasn't particularly useful for something which will only ever hold unit values. Please opine if you want to see a different design, though, since I'm open to ideas.
