### PR TITLE
Typo in Events documentation

### DIFF
--- a/Graphics/Blank/Events.hs
+++ b/Graphics/Blank/Events.hs
@@ -16,7 +16,7 @@ import TextShow.TH (deriveTextShow)
 -- Possible named events
 -- 
 -- * @keypress@, @keydown@, @keyup@
--- * @mouseDown@, @mouseenter@, @mousemove@, @mouseout@, @mouseover@, @mouseup@
+-- * @mousedown@, @mouseenter@, @mousemove@, @mouseout@, @mouseover@, @mouseup@
 type EventName = Text
 
 -- | 'EventQueue' is an STM channel ('TChan') of 'Event's.


### PR DESCRIPTION
Events must be all lowercase, so adjust the example.