### PR TITLE
Fix jsEscapeChar (handle Unicode codepoints beyond 0xFFFF)

### DIFF
--- a/Graphics/Blank/JavaScript.hs
+++ b/Graphics/Blank/JavaScript.hs
@@ -1,37 +1,40 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TemplateHaskell   #-}
 module Graphics.Blank.JavaScript where
 
-import           Data.Char (isControl, isAscii, ord)
+import           Data.Bits                       (shiftR, (.&.))
+import           Data.Char                       (isAscii, isControl, ord)
 import           Data.Colour
 import           Data.Colour.SRGB
 import           Data.Default.Class
 import           Data.Ix
 import           Data.List
 import           Data.String
-import           Data.Text.Lazy (Text, fromStrict)
-import qualified Data.Text.Lazy as TL
-import qualified Data.Text as ST
-import qualified Data.Vector.Unboxed as V
-import           Data.Vector.Unboxed (Vector, toList)
-import           Data.Word (Word8)
+import qualified Data.Text                       as ST
+import           Data.Text.Lazy                  (Text, fromStrict)
+import qualified Data.Text.Lazy                  as TL
+import           Data.Vector.Unboxed             (Vector, toList)
+import qualified Data.Vector.Unboxed             as V
+import           Data.Word                       (Word8)
 
-import           Graphics.Blank.Parser
 import           Graphics.Blank.Instr
-import qualified Graphics.Blank.Instr as I
+import qualified Graphics.Blank.Instr            as I
+import           Graphics.Blank.Parser
 
 import           Prelude.Compat
 
-import           Text.ParserCombinators.ReadP (choice, skipSpaces)
+import           Text.ParserCombinators.ReadP    (choice, skipSpaces)
 import           Text.ParserCombinators.ReadPrec (lift)
-import           Text.Read (Read(..), parens, readListPrecDefault)
+import           Text.Read                       (Read (..), parens,
+                                                  readListPrecDefault)
 
-import           TextShow hiding (toLazyText)
-import           TextShow.TH (deriveTextShow)
+import           Numeric                         (showHex)
+import           TextShow                        hiding (toLazyText)
+import           TextShow.TH                     (deriveTextShow)
 
-import qualified Network.JavaScript as JS
+import qualified Network.JavaScript              as JS
 
 -------------------------------------------------------------
 
@@ -41,8 +44,8 @@ instance InstrShow (JS.RemoteValue a) where
   showi v = I.fromText txt where JS.JavaScript txt = JS.var v
 
 -- | A handle to an offscreen canvas. 'CanvasContext' cannot be destroyed.
-data CanvasContext = 
-  CanvasContext (Maybe (JS.RemoteValue CanvasContext)) 
+data CanvasContext =
+  CanvasContext (Maybe (JS.RemoteValue CanvasContext))
   		Int
 		Int
      deriving (Eq, Ord, Show)
@@ -599,13 +602,6 @@ jsLiteralBuilder = jsQuoteBuilder . jsEscapeBuilder
 jsQuoteBuilder :: Instr -> Instr
 jsQuoteBuilder b = I.singleton '"' <> b <> I.singleton '"'
 
--- | Transform a character to a lazy 'TL.Text' that represents its JS
---   unicode escape sequence.
-jsUnicodeChar :: Char -> TL.Text
-jsUnicodeChar c =
-    let hex = toLazyText . showiHex $ ord c
-    in "\\u" <> TL.replicate (4 - TL.length hex) (TL.singleton '0') <> hex
-
 -- | Correctly replace a `Instr'`s characters by the JS escape sequences.
 jsEscapeBuilder :: Instr -> Instr
 jsEscapeBuilder = fromBuilder . fromLazyText . TL.concatMap jsEscapeChar . toLazyText
@@ -614,8 +610,6 @@ jsEscapeBuilder = fromBuilder . fromLazyText . TL.concatMap jsEscapeChar . toLaz
 jsEscapeChar :: Char -> TL.Text
 jsEscapeChar '\\' = "\\\\"
 -- Special control sequences.
-jsEscapeChar '\0' = jsUnicodeChar '\0' -- Ambigous with numbers
-jsEscapeChar '\a' = jsUnicodeChar '\a' -- Non JS
 jsEscapeChar '\b' = "\\b"
 jsEscapeChar '\f' = "\\f"
 jsEscapeChar '\n' = "\\n"
@@ -624,7 +618,17 @@ jsEscapeChar '\t' = "\\t"
 jsEscapeChar '\v' = "\\v"
 jsEscapeChar '\"' = "\\\""
 jsEscapeChar '\'' = "\\'"
--- Non-control ASCII characters can remain as they are.
-jsEscapeChar c' | not (isControl c') && isAscii c' = TL.singleton c'
--- All other non ASCII signs are escaped to unicode.
-jsEscapeChar c' = jsUnicodeChar c'
+-- Code borrowed from GHCJS implementation: https://github.com/ghcjs/ghcjs/blob/718b37fc7167269ebca633914c716c3dbe6d0faf/src/Compiler/JMacro/Base.hs#L887-L905
+jsEscapeChar '/'  = "\\/"
+jsEscapeChar c
+    -- Non-control ASCII characters can remain as they are.
+    | not (isControl c) && isAscii c = TL.singleton c
+    | ord c <= 0xff   = hexxs "\\x" 2 (ord c)
+    -- All other non ASCII signs are escaped to unicode.
+    | ord c <= 0xffff = hexxs "\\u" 4 (ord c)
+    | otherwise      = let cp0 = ord c - 0x10000 -- output surrogate pair
+                       in hexxs "\\u" 4 ((cp0 `shiftR` 10) + 0xd800) `mappend`
+                          hexxs "\\u" 4 ((cp0 .&. 0x3ff) + 0xdc00)
+    where hexxs prefix pad cp =
+            let h = showHex cp ""
+            in  TL.pack (prefix ++ replicate (pad - length h) '0' ++ h)


### PR DESCRIPTION
This PR fixes `jsEscapeChar`: in JavaScript Unicode codepoints beyond `0xFFFF` have to be encoded using surrogate pairs (for compatibility with older JavaScript versions) or using braces (e.g. `\u{1F6F8}` for 🛸 ). However, current encoding maps Haskell's `"\x1F6F8"` to JavaScript as `"\u1F6F8"`, which is parsed as `"\u{1F6F}8"` and renders `"Ὧ8"`.

The correct code is borrowed from GHCJS (see [module `Compiler.JMacro.Base`](https://github.com/ghcjs/ghcjs/blob/718b37fc7167269ebca633914c716c3dbe6d0faf/src/Compiler/JMacro/Base.hs#L887-L905)).

#### Background

When using `codeworld-api` locally with GHC, it uses `blank-canvas` to generate JavaScript instructions to render on the canvas. Unfortunately because of this bug, currently it is impossible to use Unicode symbols when using CodeWorld locally (with GHC) even though everything works fine on the Code.World platform (where they use GHCJS with correct conversion, so Unicode works properly).

Here's an example on CodeWorld:
https://code.world/haskell#PGDShdVCAXUhc9m3eJewxHg

```haskell
{-# LANGUAGE OverloadedStrings #-}
import CodeWorld

main = drawingOf (scaled 10 10 (lettering "\x1F6F8"))
```

For the same code locally this is what I see:

<img width="543" alt="Screenshot 2020-09-15 at 02 00 48" src="https://user-images.githubusercontent.com/686582/93146362-4993cf00-f6f7-11ea-88e3-4ffde0257909.png">
